### PR TITLE
feat: research agents with 5 parallel tracks

### DIFF
--- a/src/agents/research.py
+++ b/src/agents/research.py
@@ -1,0 +1,61 @@
+import asyncio
+from dataclasses import dataclass, field
+
+from src.agents.base import AgentUsage, BaseAgent
+from src.prompts.research_track import TRACK_PROMPTS
+
+
+@dataclass
+class ResearchTrack:
+    name: str
+    content: str
+    word_count: int = 0
+    data_point_count: int = 0
+
+    def __post_init__(self) -> None:
+        self.word_count = len(self.content.split())
+
+
+@dataclass
+class ResearchResult:
+    topic: str
+    tracks: list[ResearchTrack] = field(default_factory=list)
+    usage: AgentUsage = field(default_factory=AgentUsage)
+
+    @property
+    def total_words(self) -> int:
+        return sum(t.word_count for t in self.tracks)
+
+
+class ResearchAgent:
+    def __init__(self, model: str = "claude-sonnet-4-5-20250929"):
+        self.model = model
+        self.usage = AgentUsage()
+
+    async def research_track(self, track_name: str, topic: str) -> ResearchTrack:
+        agent = BaseAgent(model=self.model)
+        system = TRACK_PROMPTS.get(track_name, TRACK_PROMPTS["comparative"])
+        user = f"Research topic: {topic}\n\nProvide comprehensive, fact-dense research for this track."
+
+        content = await agent.call(system, user, max_tokens=8192)
+
+        self.usage.input_tokens += agent.usage.input_tokens
+        self.usage.output_tokens += agent.usage.output_tokens
+        self.usage.calls += agent.usage.calls
+
+        return ResearchTrack(name=track_name, content=content)
+
+    async def run_all_tracks(
+        self, topic: str, track_names: list[str] | None = None
+    ) -> ResearchResult:
+        if track_names is None:
+            track_names = list(TRACK_PROMPTS.keys())
+
+        tasks = [self.research_track(name, topic) for name in track_names]
+        tracks = await asyncio.gather(*tasks)
+
+        return ResearchResult(
+            topic=topic,
+            tracks=list(tracks),
+            usage=self.usage,
+        )

--- a/src/prompts/research_track.py
+++ b/src/prompts/research_track.py
@@ -1,0 +1,72 @@
+"""System prompts for the 5 research track agents."""
+
+TRACK_SYSTEM_BASE = """You are a research agent gathering specific, verifiable facts for a deep analysis article.
+
+RULES:
+- Every claim MUST include a specific number, date, or named entity
+- No generalizations — "the market is growing" is useless; "$2.1T market cap as of Jan 2026" is useful
+- Include source context (company name, regulatory body, data provider)
+- Focus on FACTS, not analysis — the analysis comes later
+- Minimum 15 data points per track
+- Organize by sub-topic, not by importance
+
+OUTPUT FORMAT:
+Return your research as a structured list of facts, each with:
+- The specific claim
+- The source/entity
+- The date or time period
+- Confidence level (high/medium/low)
+"""
+
+TRACK_PROMPTS = {
+    "money_flow": (
+        TRACK_SYSTEM_BASE
+        + """
+TRACK: Money Flow
+Research how money moves through the ecosystem around this topic.
+Focus on: revenue splits, fee structures, payment flows, cost structures,
+margin analysis, pricing dynamics, capital allocation, investment flows.
+Look for: who pays whom, how much, what's the unit economics.
+"""
+    ),
+    "power_structure": (
+        TRACK_SYSTEM_BASE
+        + """
+TRACK: Power & Governance
+Research who controls decisions and how power is distributed.
+Focus on: market share concentration, regulatory capture, governance mechanisms,
+switching costs, lock-in dynamics, platform dependencies.
+Look for: who has leverage over whom, what creates dependency.
+"""
+    ),
+    "regulatory": (
+        TRACK_SYSTEM_BASE
+        + """
+TRACK: Regulatory & Legal
+Research the regulatory environment and legal constraints.
+Focus on: pending legislation, enforcement actions, compliance requirements,
+regulatory arbitrage, jurisdictional differences, lobbying dynamics.
+Look for: what's changing, who benefits from current rules, who's pushing for change.
+"""
+    ),
+    "comparative": (
+        TRACK_SYSTEM_BASE
+        + """
+TRACK: Comparative & Historical
+Research analogous situations from other industries or time periods.
+Focus on: historical parallels, cross-industry patterns, failed predictions,
+similar technology transitions, comparable market structures.
+Look for: what happened when similar dynamics played out elsewhere.
+"""
+    ),
+    "practitioner": (
+        TRACK_SYSTEM_BASE
+        + """
+TRACK: Practitioner & Ground Truth
+Research what practitioners actually experience vs what's claimed.
+Focus on: developer experience, user feedback, operational challenges,
+implementation reality vs marketing claims, actual adoption data.
+Look for: the gap between narrative and ground truth.
+"""
+    ),
+}

--- a/src/tools/web_search.py
+++ b/src/tools/web_search.py
@@ -1,0 +1,32 @@
+import os
+
+import httpx
+
+
+async def perplexity_search(query: str, max_results: int = 5) -> str:
+    """Search using Perplexity API for current, sourced information."""
+    api_key = os.environ.get("PERPLEXITY_API_KEY")
+    if not api_key:
+        return f"[No PERPLEXITY_API_KEY set. Query was: {query}]"
+
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            "https://api.perplexity.ai/chat/completions",
+            headers={"Authorization": f"Bearer {api_key}"},
+            json={
+                "model": "sonar",
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": "Provide specific, sourced facts. Include dates and numbers.",
+                    },
+                    {"role": "user", "content": query},
+                ],
+            },
+            timeout=30.0,
+        )
+        if response.status_code == 200:
+            data = response.json()
+            content: str = data["choices"][0]["message"]["content"]
+            return content
+        return f"[Perplexity search failed: {response.status_code}]"

--- a/tests/test_agents/test_research.py
+++ b/tests/test_agents/test_research.py
@@ -1,0 +1,88 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.agents.research import ResearchAgent, ResearchResult, ResearchTrack
+from src.prompts.research_track import TRACK_PROMPTS
+
+
+def test_track_prompts_exist():
+    assert len(TRACK_PROMPTS) == 5
+    assert "money_flow" in TRACK_PROMPTS
+    assert "power_structure" in TRACK_PROMPTS
+    assert "regulatory" in TRACK_PROMPTS
+    assert "comparative" in TRACK_PROMPTS
+    assert "practitioner" in TRACK_PROMPTS
+
+
+def test_track_prompts_include_base():
+    for name, prompt in TRACK_PROMPTS.items():
+        assert "RULES:" in prompt, f"{name} missing rules"
+        assert "15 data points" in prompt, f"{name} missing data point requirement"
+
+
+def test_research_track_word_count():
+    track = ResearchTrack(name="test", content="word " * 100)
+    assert track.word_count == 100
+
+
+def test_research_result_total_words():
+    result = ResearchResult(
+        topic="test",
+        tracks=[
+            ResearchTrack(name="a", content="word " * 50),
+            ResearchTrack(name="b", content="word " * 75),
+        ],
+    )
+    assert result.total_words == 125
+
+
+@pytest.mark.asyncio
+async def test_research_single_track():
+    mock_response = "Fact 1: Circle paid $908M. " * 50
+
+    with patch("src.agents.research.BaseAgent") as MockAgent:
+        instance = MockAgent.return_value
+        instance.call = AsyncMock(return_value=mock_response)
+        instance.usage = MagicMock(input_tokens=500, output_tokens=1000, calls=1)
+
+        agent = ResearchAgent()
+        track = await agent.research_track("money_flow", "Stablecoin Economics")
+
+        assert track.name == "money_flow"
+        assert track.word_count > 100
+        instance.call.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_research_all_tracks():
+    mock_response = "Research data here with facts and figures. " * 100
+
+    with patch("src.agents.research.BaseAgent") as MockAgent:
+        instance = MockAgent.return_value
+        instance.call = AsyncMock(return_value=mock_response)
+        instance.usage = MagicMock(input_tokens=500, output_tokens=1000, calls=1)
+
+        agent = ResearchAgent()
+        result = await agent.run_all_tracks("Stablecoin Economics")
+
+        assert len(result.tracks) == 5
+        assert result.topic == "Stablecoin Economics"
+        assert result.total_words > 0
+
+
+@pytest.mark.asyncio
+async def test_research_custom_tracks():
+    mock_response = "Custom track research. " * 50
+
+    with patch("src.agents.research.BaseAgent") as MockAgent:
+        instance = MockAgent.return_value
+        instance.call = AsyncMock(return_value=mock_response)
+        instance.usage = MagicMock(input_tokens=500, output_tokens=1000, calls=1)
+
+        agent = ResearchAgent()
+        result = await agent.run_all_tracks(
+            "Test Topic", track_names=["money_flow", "regulatory"]
+        )
+
+        assert len(result.tracks) == 2


### PR DESCRIPTION
## Summary
- **ResearchAgent**: Runs 5 parallel research tracks via `asyncio.gather` (money flow, power/governance, regulatory, comparative, practitioner)
- **Track prompts**: Each track has specific data requirements (15+ data points, named entities, dates, sources)
- **Web search**: Perplexity API integration for current data sourcing

## Test plan
- [x] 7 new tests (86 total), all passing
- [x] Track prompts validated for completeness
- [x] Single-track and all-tracks execution tested (mocked)
- [x] Custom track subset tested
- [x] Ruff + mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)