### PR TITLE
feat: platform formatters for newsletter, LinkedIn, and X

### DIFF
--- a/src/agents/publisher.py
+++ b/src/agents/publisher.py
@@ -1,0 +1,74 @@
+"""Platform-specific formatting agents."""
+
+from dataclasses import dataclass, field
+
+from src.agents.base import AgentUsage, BaseAgent
+from src.prompts.platform_format import (
+    LINKEDIN_SYSTEM,
+    NEWSLETTER_SYSTEM,
+    X_THREAD_SYSTEM,
+)
+
+
+@dataclass
+class PublisherResult:
+    newsletter: str = ""
+    linkedin: str = ""
+    x_thread: str = ""
+    usage: AgentUsage = field(default_factory=AgentUsage)
+
+
+class PublisherAgent:
+    def __init__(self, model: str = "claude-sonnet-4-5-20250929"):
+        self.model = model
+        self.usage = AgentUsage()
+
+    async def format_newsletter(self, article: str) -> str:
+        agent = BaseAgent(model=self.model)
+        result = await agent.call(
+            NEWSLETTER_SYSTEM,
+            f"Format this article for newsletter:\n\n{article}",
+            max_tokens=8192,
+        )
+        self._add_usage(agent)
+        return result
+
+    async def format_linkedin(self, article: str) -> str:
+        agent = BaseAgent(model=self.model)
+        result = await agent.call(
+            LINKEDIN_SYSTEM,
+            f"Convert to LinkedIn post:\n\n{article}",
+            max_tokens=1024,
+        )
+        self._add_usage(agent)
+        return result
+
+    async def format_x_thread(self, article: str) -> str:
+        agent = BaseAgent(model=self.model)
+        result = await agent.call(
+            X_THREAD_SYSTEM,
+            f"Convert to X thread:\n\n{article}",
+            max_tokens=2048,
+        )
+        self._add_usage(agent)
+        return result
+
+    async def format_all(self, article: str) -> PublisherResult:
+        import asyncio
+
+        newsletter, linkedin, x_thread = await asyncio.gather(
+            self.format_newsletter(article),
+            self.format_linkedin(article),
+            self.format_x_thread(article),
+        )
+        return PublisherResult(
+            newsletter=newsletter,
+            linkedin=linkedin,
+            x_thread=x_thread,
+            usage=self.usage,
+        )
+
+    def _add_usage(self, agent: BaseAgent) -> None:
+        self.usage.input_tokens += agent.usage.input_tokens
+        self.usage.output_tokens += agent.usage.output_tokens
+        self.usage.calls += agent.usage.calls

--- a/src/prompts/platform_format.py
+++ b/src/prompts/platform_format.py
@@ -1,0 +1,58 @@
+"""Platform-specific formatting prompts."""
+
+NEWSLETTER_SYSTEM = """Format the article for newsletter distribution.
+
+Requirements:
+- Generate 3 title options following Matt Levine / Byrne Hobart style:
+  Option A: Deadpan factual ("Circle Paid Coinbase $908 Million in 2024")
+  Option B: Curious observation ("The Stablecoin Layer Nobody Owns")
+  Option C: Conversational question ("Where Does the Money Actually Go?")
+- Add a 2-sentence preview/hook for email subject
+- Preserve the full article body unchanged
+- Add a brief "What I'm reading" section with 2-3 links (placeholders)
+
+Output format:
+TITLE_A: [title]
+TITLE_B: [title]
+TITLE_C: [title]
+PREVIEW: [2-sentence hook]
+BODY:
+[full article]
+READING:
+- [placeholder link 1]
+- [placeholder link 2]"""
+
+LINKEDIN_SYSTEM = """Convert this article into a LinkedIn post.
+
+Constraints:
+- Maximum 1300 characters total
+- First line: hook that makes someone stop scrolling (NOT clickbait — use a specific number or surprising fact)
+- Second line: blank (LinkedIn truncates after ~2 lines)
+- Body: the single most surprising insight from the article, explained in 3-4 sentences
+- End with a question that invites informed comment (NOT "What do you think?")
+- No hashtags
+- No emoji
+- No "I'm excited to share..."
+- Write like you're telling a colleague something interesting over coffee
+
+Voice: Same as article — smart colleague, specific data, genuine uncertainty."""
+
+X_THREAD_SYSTEM = """Convert this article into an X/Twitter thread.
+
+Constraints:
+- 5-8 tweets maximum
+- Each tweet: max 280 characters
+- Tweet 1: The single most surprising data point or claim. No "Thread:" or "1/" prefix.
+- Tweets 2-5: Supporting evidence. Each tweet should contain at least one specific number, \
+company name, or regulatory reference.
+- Tweet 6-7: The non-obvious implication or prediction
+- Final tweet: One-sentence takeaway OR a question
+
+Rules:
+- No "Let me explain..." or "Here's why..."
+- No emoji threads
+- No numbered prefixes (1/, 2/, etc.)
+- Each tweet must stand alone — someone seeing just that tweet should find it interesting
+- Link to the full article in the final tweet (use [LINK] placeholder)
+
+Voice: Dense, specific, slightly opinionated. Like Austin Campbell's X presence."""

--- a/tests/test_agents/test_publisher.py
+++ b/tests/test_agents/test_publisher.py
@@ -1,0 +1,77 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.agents.publisher import PublisherAgent, PublisherResult
+from src.prompts.platform_format import (
+    LINKEDIN_SYSTEM,
+    NEWSLETTER_SYSTEM,
+    X_THREAD_SYSTEM,
+)
+
+
+def test_newsletter_prompt():
+    assert "title" in NEWSLETTER_SYSTEM.lower()
+    assert "Matt Levine" in NEWSLETTER_SYSTEM
+    assert "TITLE_A" in NEWSLETTER_SYSTEM
+
+
+def test_linkedin_prompt():
+    assert "1300 characters" in LINKEDIN_SYSTEM
+    assert "No hashtags" in LINKEDIN_SYSTEM
+    assert "No emoji" in LINKEDIN_SYSTEM
+
+
+def test_x_thread_prompt():
+    assert "280 characters" in X_THREAD_SYSTEM
+    assert "5-8 tweets" in X_THREAD_SYSTEM
+    assert "[LINK]" in X_THREAD_SYSTEM
+
+
+def _mock_agent():
+    mock = MagicMock()
+    mock.call = AsyncMock(return_value="Formatted output.")
+    mock.usage = MagicMock(input_tokens=200, output_tokens=500, calls=1)
+    return mock
+
+
+@pytest.mark.asyncio
+async def test_format_newsletter():
+    with patch("src.agents.publisher.BaseAgent", return_value=_mock_agent()):
+        agent = PublisherAgent()
+        result = await agent.format_newsletter("Article text here")
+        assert len(result) > 0
+
+
+@pytest.mark.asyncio
+async def test_format_linkedin():
+    with patch("src.agents.publisher.BaseAgent", return_value=_mock_agent()):
+        agent = PublisherAgent()
+        result = await agent.format_linkedin("Article text here")
+        assert len(result) > 0
+
+
+@pytest.mark.asyncio
+async def test_format_x_thread():
+    with patch("src.agents.publisher.BaseAgent", return_value=_mock_agent()):
+        agent = PublisherAgent()
+        result = await agent.format_x_thread("Article text here")
+        assert len(result) > 0
+
+
+@pytest.mark.asyncio
+async def test_format_all():
+    with patch("src.agents.publisher.BaseAgent", return_value=_mock_agent()):
+        agent = PublisherAgent()
+        result = await agent.format_all("Article text here")
+        assert isinstance(result, PublisherResult)
+        assert len(result.newsletter) > 0
+        assert len(result.linkedin) > 0
+        assert len(result.x_thread) > 0
+
+
+def test_publisher_result_defaults():
+    result = PublisherResult()
+    assert result.newsletter == ""
+    assert result.linkedin == ""
+    assert result.x_thread == ""


### PR DESCRIPTION
## Summary
- **PublisherAgent** with parallel formatting via `asyncio.gather` for 3 platforms
- **Newsletter**: 3 title options (Levine/Hobart style), preview hook, reading links
- **LinkedIn**: 1300-char max, data-driven hook, no hashtags/emoji, colleague voice
- **X thread**: 5-8 standalone tweets with specific data, [LINK] placeholder

## Test plan
- [x] 117 tests passing (8 new for publisher)
- [x] ruff clean
- [x] mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-platform content formatter to generate optimized versions of articles for newsletter, LinkedIn, and X/Twitter distribution.

* **Tests**
  * Added comprehensive test coverage for multi-platform content formatting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->