### PR TITLE
feat: pipeline orchestrator with quality gates and content store

### DIFF
--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -1,0 +1,244 @@
+"""Full pipeline orchestrator with state management and quality gates."""
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from src.agents.base import AgentUsage
+from src.agents.debate import DebateAgent
+from src.agents.disorder import DisorderAgent
+from src.agents.insight import InsightPipeline
+from src.agents.publisher import PublisherAgent
+from src.agents.research import ResearchAgent
+from src.agents.writer import WriterAgent
+from src.config import load_pipeline_config, load_quality_thresholds
+from src.quality.burstiness import compute_burstiness
+from src.quality.structural_scanner import scan_structural
+from src.quality.vocabulary_scanner import scan_vocabulary
+from src.storage.content_store import ContentStore
+
+
+@dataclass
+class PipelineState:
+    topic: str = ""
+    tier: int = 1
+    phase_outputs: dict[str, Any] = field(default_factory=dict)
+    scores: dict[str, Any] = field(default_factory=dict)
+    usage: AgentUsage = field(default_factory=AgentUsage)
+    current_phase: str = ""
+    completed_phases: list[str] = field(default_factory=list)
+
+
+@dataclass
+class QualityGateResult:
+    passed: bool = True
+    failures: list[str] = field(default_factory=list)
+    scores: dict[str, float] = field(default_factory=dict)
+
+
+class PipelineOrchestrator:
+    def __init__(self, tier: int = 1) -> None:
+        self.tier = tier
+        self.config = load_pipeline_config()
+        self.thresholds = load_quality_thresholds()
+        self.state = PipelineState(tier=tier)
+        self.store = ContentStore()
+
+    def _should_skip(self, phase_name: str) -> bool:
+        tier_config = self.config["tiers"].get(self.tier, {})
+        skip = tier_config.get("skip_phases", [])
+        return phase_name in skip
+
+    def _add_usage(self, usage: AgentUsage) -> None:
+        self.state.usage.input_tokens += usage.input_tokens
+        self.state.usage.output_tokens += usage.output_tokens
+        self.state.usage.calls += usage.calls
+
+    async def run_research(self, topic: str) -> str:
+        self.state.current_phase = "saturate"
+        agent = ResearchAgent()
+        result = await agent.run_all_tracks(topic)
+        combined = "\n\n".join(
+            f"## {t.name}\n{t.content}" for t in result.tracks
+        )
+        self.state.phase_outputs["research"] = combined
+        self._add_usage(result.usage)
+        self.state.completed_phases.append("saturate")
+        return combined
+
+    async def run_insight(self, research: str) -> str:
+        self.state.current_phase = "insight"
+        pipeline = InsightPipeline()
+        result = await pipeline.run(research)
+        insight = (
+            f"## Anomalies\n{result.anomalies}\n\n"
+            f"## Cross-References\n{result.cross_references}\n\n"
+            f"## Mechanism\n{result.mechanism}\n\n"
+            f"## Predictions\n{result.predictions}\n\n"
+            f"## Validation\n{result.validation}"
+        )
+        self.state.phase_outputs["insight"] = insight
+        self._add_usage(result.usage)
+        self.state.completed_phases.extend(
+            ["anomalies", "cross_reference", "mechanism", "predict", "validate"]
+        )
+        return insight
+
+    async def run_debate(self, research: str, anomalies: str) -> str:
+        if self._should_skip("debate"):
+            return ""
+        self.state.current_phase = "debate"
+        agent = DebateAgent()
+        result = await agent.run(research, anomalies)
+        self.state.phase_outputs["debate"] = result.synthesis
+        self._add_usage(result.usage)
+        self.state.completed_phases.append("debate")
+        return result.synthesis
+
+    async def run_disorder(self, research: str, insight: str) -> str:
+        self.state.current_phase = "disorder"
+        agent = DisorderAgent()
+        result = await agent.disorder(research, insight)
+        self.state.phase_outputs["disorder"] = result.outline
+        self._add_usage(result.usage)
+        self.state.completed_phases.append("disorder")
+        return result.outline
+
+    async def run_write(self, outline: str, research: str) -> str:
+        self.state.current_phase = "write"
+        agent = WriterAgent()
+        result = await agent.write_and_revise(outline, research)
+        self.state.phase_outputs["draft"] = result.draft
+        self._add_usage(result.usage)
+        self.state.completed_phases.append("write")
+        return result.draft
+
+    def run_quality_scan(self, article: str) -> QualityGateResult:
+        self.state.current_phase = "quality_scan"
+        gate = QualityGateResult()
+
+        structural = scan_structural(article)
+        vocab = scan_vocabulary(article)
+        burstiness = compute_burstiness(article)
+
+        gate.scores["structural"] = structural.score(self.thresholds)
+        gate.scores["vocabulary"] = vocab.score(self.thresholds)
+        gate.scores["burstiness"] = burstiness
+
+        # Check structural thresholds
+        st = self.thresholds.get("structural", {})
+        if "sentence_length_cv" in st:
+            if structural.sentence_length_cv < st["sentence_length_cv"].get("min", 0):
+                gate.failures.append(
+                    f"sentence_length_cv={structural.sentence_length_cv:.2f} "
+                    f"< {st['sentence_length_cv']['min']}"
+                )
+
+        # Check anti-AI thresholds
+        anti = self.thresholds.get("anti_ai", {})
+        if "banned_words" in anti:
+            if vocab.banned_word_count > anti["banned_words"].get("max", 0):
+                gate.failures.append(
+                    f"banned_words={vocab.banned_word_count} "
+                    f"> {anti['banned_words']['max']}"
+                )
+        if "burstiness_score" in anti:
+            if burstiness < anti["burstiness_score"].get("min", 0):
+                gate.failures.append(
+                    f"burstiness={burstiness:.2f} "
+                    f"< {anti['burstiness_score']['min']}"
+                )
+
+        # Check voice thresholds
+        voice = self.thresholds.get("voice", {})
+        if "conjunction_starts" in voice:
+            if vocab.conjunction_starts < voice["conjunction_starts"].get("min", 0):
+                gate.failures.append(
+                    f"conjunction_starts={vocab.conjunction_starts} "
+                    f"< {voice['conjunction_starts']['min']}"
+                )
+        if "fragments" in voice:
+            if vocab.fragment_count < voice["fragments"].get("min", 0):
+                gate.failures.append(
+                    f"fragments={vocab.fragment_count} "
+                    f"< {voice['fragments']['min']}"
+                )
+
+        gate.passed = len(gate.failures) == 0
+        self.state.scores = gate.scores
+        self.state.completed_phases.append("quality_scan")
+        return gate
+
+    async def run_revision(
+        self, article: str, failures: list[str], max_iterations: int = 3
+    ) -> str:
+        self.state.current_phase = "revision"
+        agent = WriterAgent()
+        current = article
+        for i in range(max_iterations):
+            scan_text = "\n".join(f"- {f}" for f in failures)
+            current = await agent.revise(current, scan_text)
+            self._add_usage(agent.agent.usage)
+
+            gate = self.run_quality_scan(current)
+            if gate.passed:
+                break
+            failures = gate.failures
+
+        self.state.phase_outputs["revision"] = current
+        self.state.completed_phases.append("revision")
+        return current
+
+    async def run_publish(self, article: str) -> dict[str, str]:
+        self.state.current_phase = "platform_format"
+        agent = PublisherAgent()
+        result = await agent.format_all(article)
+        output = {
+            "newsletter": result.newsletter,
+            "linkedin": result.linkedin,
+            "x_thread": result.x_thread,
+        }
+        self.state.phase_outputs["publish"] = output
+        self._add_usage(result.usage)
+        self.state.completed_phases.append("platform_format")
+        return output
+
+    async def run_full(self, topic: str) -> PipelineState:
+        self.state.topic = topic
+
+        # Phase 1: Research
+        research = await self.run_research(topic)
+
+        # Phase 2: Insight generation
+        insight = await self.run_insight(research)
+
+        # Phase 3: Debate (tier 3 only)
+        await self.run_debate(research, insight)
+
+        # Phase 4: DISORDER
+        outline = await self.run_disorder(research, insight)
+
+        # Phase 5: Write
+        article = await self.run_write(outline, research)
+
+        # Phase 6: Quality scan
+        gate = self.run_quality_scan(article)
+
+        # Phase 7: Revision if needed
+        if not gate.passed:
+            article = await self.run_revision(article, gate.failures)
+
+        # Phase 8: Platform formatting
+        await self.run_publish(article)
+
+        # Save outputs
+        cost = self.state.usage.estimated_cost("claude-opus-4-6")
+        self.store.save_run(
+            topic=topic,
+            tier=self.tier,
+            phases=self.state.phase_outputs,
+            article=article,
+            scores=self.state.scores,
+            cost=cost,
+        )
+
+        return self.state

--- a/src/storage/content_store.py
+++ b/src/storage/content_store.py
@@ -1,0 +1,59 @@
+"""Version-controlled content storage with metadata."""
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+OUTPUT_DIR = Path("output")
+
+
+class ContentStore:
+    def __init__(self, base_dir: Path | None = None):
+        self.base_dir = base_dir or OUTPUT_DIR
+
+    def save_run(
+        self,
+        topic: str,
+        tier: int,
+        phases: dict[str, Any],
+        article: str,
+        scores: dict[str, Any],
+        cost: float,
+    ) -> Path:
+        timestamp = datetime.now(UTC).strftime("%Y%m%d_%H%M%S")
+        slug = topic.lower().replace(" ", "-")[:40]
+        run_dir = self.base_dir / f"{timestamp}_{slug}"
+        run_dir.mkdir(parents=True, exist_ok=True)
+
+        # Save article
+        (run_dir / "article.md").write_text(article)
+
+        # Save metadata
+        meta = {
+            "topic": topic,
+            "tier": tier,
+            "timestamp": timestamp,
+            "scores": scores,
+            "cost_usd": cost,
+            "phases_completed": list(phases.keys()),
+        }
+        (run_dir / "metadata.json").write_text(json.dumps(meta, indent=2))
+
+        # Save each phase output
+        phases_dir = run_dir / "phases"
+        phases_dir.mkdir(exist_ok=True)
+        for name, content in phases.items():
+            (phases_dir / f"{name}.md").write_text(str(content))
+
+        return run_dir
+
+    def list_runs(self) -> list[dict[str, Any]]:
+        if not self.base_dir.exists():
+            return []
+        runs = []
+        for run_dir in sorted(self.base_dir.iterdir(), reverse=True):
+            meta_path = run_dir / "metadata.json"
+            if meta_path.exists():
+                runs.append(json.loads(meta_path.read_text()))
+        return runs

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,0 +1,128 @@
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.orchestrator import PipelineOrchestrator, PipelineState, QualityGateResult
+from src.storage.content_store import ContentStore
+
+
+def test_pipeline_state_defaults():
+    state = PipelineState()
+    assert state.topic == ""
+    assert state.tier == 1
+    assert state.phase_outputs == {}
+
+
+def test_quality_gate_result_defaults():
+    gate = QualityGateResult()
+    assert gate.passed is True
+    assert gate.failures == []
+
+
+def test_should_skip_tier1():
+    orch = PipelineOrchestrator(tier=1)
+    assert orch._should_skip("debate") is True
+    assert orch._should_skip("forced_impasse") is True
+    assert orch._should_skip("bisociate") is True
+    assert orch._should_skip("saturate") is False
+
+
+def test_should_skip_tier3():
+    orch = PipelineOrchestrator(tier=3)
+    assert orch._should_skip("debate") is False
+    assert orch._should_skip("forced_impasse") is False
+
+
+def test_quality_scan_real_article(article_02):
+    orch = PipelineOrchestrator(tier=1)
+    gate = orch.run_quality_scan(article_02)
+    assert "structural" in gate.scores
+    assert "vocabulary" in gate.scores
+    assert "burstiness" in gate.scores
+
+
+def test_content_store_save_and_list(tmp_path: Path):
+    store = ContentStore(base_dir=tmp_path / "output")
+    run_dir = store.save_run(
+        topic="Test Topic",
+        tier=1,
+        phases={"research": "research output", "draft": "draft output"},
+        article="# Test Article\n\nContent here.",
+        scores={"structural": 7.5, "vocabulary": 8.0},
+        cost=5.50,
+    )
+    assert run_dir.exists()
+    assert (run_dir / "article.md").exists()
+    assert (run_dir / "metadata.json").exists()
+    assert (run_dir / "phases" / "research.md").exists()
+
+    meta = json.loads((run_dir / "metadata.json").read_text())
+    assert meta["topic"] == "Test Topic"
+    assert meta["cost_usd"] == 5.50
+
+    runs = store.list_runs()
+    assert len(runs) == 1
+    assert runs[0]["topic"] == "Test Topic"
+
+
+def test_content_store_empty(tmp_path: Path):
+    store = ContentStore(base_dir=tmp_path / "nonexistent")
+    assert store.list_runs() == []
+
+
+@pytest.mark.asyncio
+async def test_run_research():
+    mock_result = MagicMock()
+    mock_result.tracks = [
+        MagicMock(name="money_flow", content="Money data..."),
+        MagicMock(name="regulatory", content="Reg data..."),
+    ]
+    mock_result.usage = MagicMock(input_tokens=500, output_tokens=2000, calls=2)
+
+    with patch("src.orchestrator.ResearchAgent") as mock_ra:
+        mock_ra.return_value.run_all_tracks = AsyncMock(return_value=mock_result)
+        orch = PipelineOrchestrator(tier=1)
+        result = await orch.run_research("stablecoins")
+        assert len(result) > 0
+        assert "saturate" in orch.state.completed_phases
+
+
+@pytest.mark.asyncio
+async def test_run_insight():
+    mock_result = MagicMock()
+    mock_result.anomalies = "Anomaly 1"
+    mock_result.cross_references = "Cross ref"
+    mock_result.mechanism = "Mechanism"
+    mock_result.predictions = "Predictions"
+    mock_result.validation = "Validation"
+    mock_result.usage = MagicMock(input_tokens=1000, output_tokens=3000, calls=5)
+
+    with patch("src.orchestrator.InsightPipeline") as mock_ip:
+        mock_ip.return_value.run = AsyncMock(return_value=mock_result)
+        orch = PipelineOrchestrator(tier=1)
+        result = await orch.run_insight("research text")
+        assert "Anomalies" in result
+        assert "anomalies" in orch.state.completed_phases
+
+
+@pytest.mark.asyncio
+async def test_run_debate_skipped_tier1():
+    orch = PipelineOrchestrator(tier=1)
+    result = await orch.run_debate("research", "anomalies")
+    assert result == ""
+
+
+@pytest.mark.asyncio
+async def test_run_debate_tier3():
+    mock_result = MagicMock()
+    mock_result.synthesis = "Winning hypothesis"
+    mock_result.usage = MagicMock(input_tokens=500, output_tokens=1000, calls=5)
+
+    with patch("src.orchestrator.DebateAgent") as mock_da:
+        mock_da.return_value.run = AsyncMock(return_value=mock_result)
+        orch = PipelineOrchestrator(tier=3)
+        result = await orch.run_debate("research", "anomalies")
+        assert result == "Winning hypothesis"
+        assert "debate" in orch.state.completed_phases


### PR DESCRIPTION
## Summary
- **PipelineOrchestrator**: ties all agents into a single `run_full(topic)` pipeline
- **Tier-aware skipping**: debate (tier 3 only), forced_impasse/bisociate (tier 2+)
- **Quality gates**: structural scan + vocabulary scan + burstiness → revision loop (max 3 iterations)
- **ContentStore**: saves each run with article, metadata.json, and per-phase outputs
- **Cost tracking**: cumulative AgentUsage across all phases

## Test plan
- [x] 128 tests passing (11 new for orchestrator + content store)
- [x] ruff clean
- [x] mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)