### PR TITLE
feat: calibrate quality thresholds against existing articles

### DIFF
--- a/config/quality_thresholds.yaml
+++ b/config/quality_thresholds.yaml
@@ -1,10 +1,15 @@
+# Calibrated against articles 02, 03, 04 (2026-02-07)
+# Article 02: structural=7.8, vocab=6.0, burstiness=0.42
+# Article 03: structural=6.7, vocab=8.0, burstiness=0.37
+# Article 04: structural=6.7, vocab=8.0, burstiness=0.43
+
 structural:
   sentence_length_cv:
     min: 0.35
     description: "Coefficient of variation of sentence lengths"
   paragraph_word_std:
-    min: 35
-    description: "Standard deviation of paragraph word counts"
+    min: 20
+    description: "Standard deviation of paragraph word counts (calibrated: articles at 22-27)"
   single_sentence_paragraphs:
     min: 3
     description: "Number of single-sentence paragraphs"
@@ -13,24 +18,24 @@ structural:
     description: "Formal transitions (Furthermore, Moreover, etc.) per 1000 words"
   self_refs_per_1k:
     min: 4.0
-    max: 6.0
-    description: "Self-references (I, my, me) per 1000 words"
+    max: 18.0
+    description: "Self-references (I, my, me) per 1000 words (calibrated: articles at 7-16)"
   data_per_paragraph:
     min: 1.3
     max: 2.5
     description: "Data points per paragraph (LLM-assessed)"
   section_ratio:
     min: 2.0
-    max: 5.0
-    description: "Ratio of longest to shortest section word count"
+    max: 12.0
+    description: "Ratio of longest to shortest section (calibrated: article 04 at 10.7)"
   solution_pct:
     max: 7
     description: "Percentage of total words in solution/conclusion sections"
 
 anti_ai:
   banned_words:
-    max: 0
-    description: "Count of banned AI words"
+    max: 2
+    description: "Count of banned AI words (calibrated: article 02 has 'leverage')"
   signposting:
     max: 2
     description: "Instances of announcing what text will do"
@@ -47,13 +52,13 @@ anti_ai:
     max: 0
     description: "Instances of telling reader about your feelings"
   burstiness_score:
-    min: 0.5
-    description: "Sentence length variation clustering score"
+    min: 0.3
+    description: "Sentence length variation clustering (calibrated: articles at 0.37-0.43)"
 
 voice:
   fragments:
-    min: 3
-    description: "Sentence fragments used for effect"
+    min: 1
+    description: "Sentence fragments used for effect (calibrated: articles at 1-2)"
   conjunction_starts:
     min: 5
     description: "Sentences starting with And/But/So"

--- a/scripts/calibrate.py
+++ b/scripts/calibrate.py
@@ -1,0 +1,68 @@
+"""Run quality scanners against existing articles and print calibration data."""
+
+from pathlib import Path
+
+from src.config import load_quality_thresholds
+from src.quality.burstiness import compute_burstiness
+from src.quality.structural_scanner import scan_structural
+from src.quality.vocabulary_scanner import scan_vocabulary
+
+ARTICLES = {
+    "02": Path("content/02-insight-ai-capex-stablecoins.md"),
+    "03": Path("content/03-insight-what-ai-actually-means.md"),
+    "04": Path("content/04-insight-compression-substitution.md"),
+}
+
+
+def main():
+    thresholds = load_quality_thresholds()
+
+    for name, path in ARTICLES.items():
+        if not path.exists():
+            print(f"\n{name}: FILE NOT FOUND ({path})")
+            continue
+
+        text = path.read_text()
+        structural = scan_structural(text)
+        vocab = scan_vocabulary(text)
+        burstiness = compute_burstiness(text)
+
+        print(f"\n{'='*60}")
+        print(f"Article {name}: {path.name}")
+        print(f"{'='*60}")
+        print(f"Word count: {len(text.split())}")
+        print()
+
+        print("STRUCTURAL:")
+        print(f"  sentence_length_cv:          {structural.sentence_length_cv:.3f}")
+        print(f"  paragraph_word_std:          {structural.paragraph_word_std:.1f}")
+        print(f"  single_sentence_paragraphs:  {structural.single_sentence_paragraphs}")
+        print(f"  formal_transitions_per_1k:   {structural.formal_transitions_per_1k:.2f}")
+        print(f"  self_refs_per_1k:            {structural.self_refs_per_1k:.2f}")
+        print(f"  section_ratio:               {structural.section_ratio:.2f}")
+        print(f"  solution_pct:                {structural.solution_pct:.1f}")
+        print(f"  SCORE: {structural.score(thresholds):.1f}/10")
+        if structural.issues:
+            for issue in structural.issues:
+                print(f"  ISSUE: {issue}")
+        print()
+
+        print("VOCABULARY:")
+        print(f"  banned_word_count:           {vocab.banned_word_count}")
+        if vocab.banned_words_found:
+            print(f"  banned_words_found:          {vocab.banned_words_found}")
+        print(f"  not_x_its_y_count:           {vocab.not_x_its_y_count}")
+        print(f"  fragment_count:              {vocab.fragment_count}")
+        print(f"  conjunction_starts:          {vocab.conjunction_starts}")
+        print(f"  contractions_per_200w:       {vocab.contractions_per_200w:.2f}")
+        print(f"  em_dashes_per_1k:            {vocab.em_dashes_per_1k:.2f}")
+        print(f"  SCORE: {vocab.score(thresholds):.1f}/10")
+        print()
+
+        print("BURSTINESS:")
+        print(f"  score: {burstiness:.3f}")
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -86,8 +86,8 @@ def test_quality_thresholds_structural(quality_thresholds):
 
 def test_quality_thresholds_anti_ai(quality_thresholds):
     anti_ai = quality_thresholds["anti_ai"]
-    assert anti_ai["banned_words"]["max"] == 0
-    assert anti_ai["burstiness_score"]["min"] == 0.5
+    assert anti_ai["banned_words"]["max"] == 2
+    assert anti_ai["burstiness_score"]["min"] == 0.3
 
 
 def test_article_fixtures_load(article_02, article_03, article_04):


### PR DESCRIPTION
## Summary
Ran quality scanners against articles 02/03/04 and tuned thresholds to match real article characteristics:

| Metric | Before | After | Reason |
|--------|--------|-------|--------|
| paragraph_word_std min | 35 | 20 | Articles at 22-27 |
| self_refs_per_1k max | 6.0 | 18.0 | Articles at 7-16 |
| section_ratio max | 5.0 | 12.0 | Article 04 at 10.7 |
| burstiness_score min | 0.5 | 0.3 | Articles at 0.37-0.43 |
| fragments min | 3 | 1 | Articles at 1-2 |
| banned_words max | 0 | 2 | Article 02 uses "leverage" |

Added `scripts/calibrate.py` for future recalibration.

## Test plan
- [x] 155 tests passing
- [x] All 3 articles score 6.7+ structural, 10/10 vocabulary after calibration

🤖 Generated with [Claude Code](https://claude.com/claude-code)